### PR TITLE
writing to memory is faster than writing to files

### DIFF
--- a/str_putcsv.php
+++ b/str_putcsv.php
@@ -9,7 +9,7 @@ if (!function_exists('str_putcsv'))
         $escape = $escape ?? '\\';
 
         // Open an in-memory file resource
-        $fp = fopen('php://temp', 'r+b');
+        $fp = fopen('php://memory', 'r+b');
 
         try {
             // Write the fields array to the file resource as a CSV line


### PR DESCRIPTION
The php://temp stream might ([after 2MB!](https://www.php.net/manual/en/wrappers.php.php#wrappers.php.memory)) write to a file, which will be slower.